### PR TITLE
Hi, 

### DIFF
--- a/jqm.autoComplete-1.3.js
+++ b/jqm.autoComplete-1.3.js
@@ -74,6 +74,10 @@
 						return re.test(element_text);
 					});
 					buildItems($this, data, settings);
+				}  else if ($.isFunction(settings.source)) {
+					settings.source (text, function(data) {
+						buildItems($this, data, settings);
+					});
 				} else {
 					$.get(settings.source, { term: text }, function(data) {
 						buildItems($this, data, settings);


### PR DESCRIPTION
I added a few lines of code that existed in jqm.Autocomplete-1.2 and that allowed me to use a function as to retrieve the source. Specifically, I use this to retrieve Google.Maps.Geocode addresses as soon as the user types in the autocomplete field.
