### PR TITLE
Extended AJAX JSON support and optional vaolue encode

### DIFF
--- a/jqm.autoComplete-1.4.js
+++ b/jqm.autoComplete-1.4.js
@@ -13,6 +13,7 @@
 
 	var defaults = {
 		method: 'GET',
+		contentType: 'application/x-www-form-urlencoded',
 		icon: 'arrow-r',
 		cancelRequests: false,
 		target: $(),
@@ -20,7 +21,8 @@
 		callback: null,
 		link: null,
 		minLength: 0,
-		transition: 'fade'
+		transition: 'fade',
+		encodeValue: true
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
@@ -29,9 +31,11 @@
 			$.each(data, function(index, value) {
 				// are we working with objects or strings?
 				if ($.isPlainObject(value)) {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
-				} else {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
+					if (settings.encodeValue) usevalue = encodeURIComponent(value.value); else usevalue = value.value;
+	                		str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link +  usevalue + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
+	                	} else {
+                    			if (settings.encodeValue) usevalue = encodeURIComponent(value); else usevalue = value;
+	                		str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + value + '" data-transition="' + settings.transition + '">' + value + '</a></li>');					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
 				}
 			});
 		}
@@ -94,7 +98,8 @@
 					$.ajax({
 						type: settings.method,
 						url: settings.source,
-						data: { term: text },
+						data: JSON.stringify({term: text }),
+                        			contentType: settings.contentType,
 						beforeSend: function(jqXHR) {
 							if (settings.cancelRequests) {
 								if (openXHR[id]) {
@@ -110,7 +115,7 @@
 							}
 						},
 						success: function(data) {
-							buildItems($this, data, settings);
+							if (data.d) buildItems($this, data.d, settings); else buildItems($this, data, settings);
 						},
 						complete: function (jqXHR, textStatus) {
 							// Clear this ID's open XML HTTP Request from the list

--- a/jqm.autoComplete-1.4.js
+++ b/jqm.autoComplete-1.4.js
@@ -13,6 +13,7 @@
 
 	var defaults = {
 		method: 'GET',
+	        contentType: 'application/x-www-form-urlencoded',
 		icon: 'arrow-r',
 		cancelRequests: false,
 		target: $(),
@@ -20,17 +21,20 @@
 		callback: null,
 		link: null,
 		minLength: 0,
-		transition: 'fade'
+		transition: 'fade',
+	        encodeValue: true
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
-		var str = [];
+		var str = [], usevalue = '';
 		if (data) {
 			$.each(data, function(index, value) {
 				// are we working with objects or strings?
 				if ($.isPlainObject(value)) {
+		                	if (settings.encodeValue) usevalue = encodeURIComponent(value.value); else usevalue = value.value;
 					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
 				} else {
+					if (settings.encodeValue) usevalue = encodeURIComponent(value); else usevalue = value;
 					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
 				}
 			});
@@ -95,6 +99,7 @@
 						type: settings.method,
 						url: settings.source,
 						data: { term: text },
+						contentType: settings.contentType,
 						beforeSend: function(jqXHR) {
 							if (settings.cancelRequests) {
 								if (openXHR[id]) {
@@ -110,7 +115,7 @@
 							}
 						},
 						success: function(data) {
-							buildItems($this, data, settings);
+							if (data.d) buildItems($this, data.d, settings); else buildItems($this, data, settings);
 						},
 						complete: function (jqXHR, textStatus) {
 							// Clear this ID's open XML HTTP Request from the list

--- a/jqm.autoComplete-1.4.js
+++ b/jqm.autoComplete-1.4.js
@@ -13,7 +13,6 @@
 
 	var defaults = {
 		method: 'GET',
-	        contentType: 'application/x-www-form-urlencoded',
 		icon: 'arrow-r',
 		cancelRequests: false,
 		target: $(),
@@ -21,20 +20,17 @@
 		callback: null,
 		link: null,
 		minLength: 0,
-		transition: 'fade',
-	        encodeValue: true
+		transition: 'fade'
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
-		var str = [], usevalue = '';
+		var str = [];
 		if (data) {
 			$.each(data, function(index, value) {
 				// are we working with objects or strings?
 				if ($.isPlainObject(value)) {
-		                	if (settings.encodeValue) usevalue = encodeURIComponent(value.value); else usevalue = value.value;
 					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
 				} else {
-					if (settings.encodeValue) usevalue = encodeURIComponent(value); else usevalue = value;
 					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
 				}
 			});
@@ -99,7 +95,6 @@
 						type: settings.method,
 						url: settings.source,
 						data: { term: text },
-						contentType: settings.contentType,
 						beforeSend: function(jqXHR) {
 							if (settings.cancelRequests) {
 								if (openXHR[id]) {
@@ -115,7 +110,7 @@
 							}
 						},
 						success: function(data) {
-							if (data.d) buildItems($this, data.d, settings); else buildItems($this, data, settings);
+							buildItems($this, data, settings);
 						},
 						complete: function (jqXHR, textStatus) {
 							// Clear this ID's open XML HTTP Request from the list


### PR DESCRIPTION
Added the contentType ajax option defaults to 'application/x-www-form-urlencoded' can be changed to 'application/json; charset=utf-8' which is required for .net web service support. To support this
this the response must check data.d not just data - this has been added so both responses are supported..

Also to support the use of a URL (or other non encode required values) as the returned value the
encodeURIComponent in the buildItems function must be able disabled, so the new option encodeValue was added this defaults to true which means the value is encoded - set to false to support URL or non encode required values.
