### PR TITLE
A set of changes to make it way more flexible

### DIFF
--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -86,7 +86,8 @@
                 $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').nextAll('li.ui-btn:eq(0)').addClass('ui-btn-active').length
                     || $('.ui-btn:first', $(settings.target)).addClass('ui-btn-active');
             } else if (e.keyCode == 13) {
-                $('.ui-btn-active a', $(settings.target)).click();
+                $('.ui-btn-active a', $(settings.target)).click().length
+                || $('.ui-btn:first a', $(settings.target)).click();
             }
         }
 		if (settings) {

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -80,10 +80,10 @@
 			re;
         if (e) {
             if (e.keyCode == 38) { // up
-                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prev('li.ui-btn').addClass('ui-btn-active').length
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prevAll('li.ui-btn:eq(0)').addClass('ui-btn-active').length
                     || $('.ui-btn:last', $(settings.target)).addClass('ui-btn-active');
             } else if (e.keyCode == 40) {
-                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').next('li.ui-btn').addClass('ui-btn-active').length
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').nextAll('li.ui-btn:eq(0)').addClass('ui-btn-active').length
                     || $('.ui-btn:first', $(settings.target)).addClass('ui-btn-active');
             } else if (e.keyCode == 13) {
                 $('.ui-btn-active a', $(settings.target)).click();

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -73,6 +73,9 @@
 		if (settings) {
 			// get the current text of the input field
 			text = $this.val();
+            // check if it's the same as the last one
+            if (settings._lastText === text) return;
+            settings._lastText = text;
 			// if we don't have enough text zero out the target
 			if (text.length < settings.minLength) {
 				clearTarget($this, $(settings.target));

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -78,6 +78,18 @@
 			settings = $this.jqmData("autocomplete"),
 			element_text,
 			re;
+        if (e) {
+            console.log(e.keyCode);
+            if (e.keyCode == 38) { // up
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prev('li.ui-btn').addClass('ui-btn-active').length
+                    || $('.ui-btn:last', $(settings.target)).addClass('ui-btn-active');
+            } else if (e.keyCode == 40) {
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').next('li.ui-btn').addClass('ui-btn-active').length
+                    || $('.ui-btn:first', $(settings.target)).addClass('ui-btn-active');
+            } else if (e.keyCode == 13) {
+                $('.ui-btn-active a', $(settings.target)).click();
+            }
+        }
 		if (settings) {
 			// get the current text of the input field
 			text = $this.val();
@@ -87,6 +99,8 @@
             if (settings._retryTimeout) {
                 window.clearTimeout(settings._retryTimeout);
                 settings._retryTimeout = null;
+                // dont change the result the user is browsing...
+                if (e && (e.keyCode == 13 || e.keyCode == 38 || e.keyCode == 40)) return;
             }
 			// if we don't have enough text zero out the target
 			if (text.length < settings.minLength) {

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -79,7 +79,6 @@
 			element_text,
 			re;
         if (e) {
-            console.log(e.keyCode);
             if (e.keyCode == 38) { // up
                 $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prev('li.ui-btn').addClass('ui-btn-active').length
                     || $('.ui-btn:last', $(settings.target)).addClass('ui-btn-active');
@@ -99,9 +98,9 @@
             if (settings._retryTimeout) {
                 window.clearTimeout(settings._retryTimeout);
                 settings._retryTimeout = null;
-                // dont change the result the user is browsing...
-                if (e && (e.keyCode == 13 || e.keyCode == 38 || e.keyCode == 40)) return;
             }
+            // dont change the result the user is browsing...
+            if (e && (e.keyCode == 13 || e.keyCode == 38 || e.keyCode == 40)) return;
 			// if we don't have enough text zero out the target
 			if (text.length < settings.minLength) {
 				clearTarget($this, $(settings.target));

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -24,22 +24,29 @@
 		matchFromStart: true,
         termParam : 'term',
         loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>',
-        interval : 0
+        interval : 0,
+        builder : null
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
-		var str = [];
-		if (data) {
-			$.each(data, function(index, value) {
-				// are we working with objects or strings?
-				if ($.isPlainObject(value)) {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
-				} else {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
-				}
-			});
-		}
-		$(settings.target).html(str.join('')).listview("refresh");
+		var str;
+        if (settings.builder) {
+            str = settings.builder.apply($this.eq(0), [data, settings]);
+        } else {
+            str = [];
+            if (data) {
+                $.each(data, function(index, value) {
+                    // are we working with objects or strings?
+                    if ($.isPlainObject(value)) {
+                        str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
+                    } else {
+                        str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
+                    }
+                });
+            }
+        }
+        if ($.isArray(str)) str = str.join('');
+		$(settings.target).html(str).listview("refresh");
 
 		// is there a callback?
 		if (settings.callback !== null && $.isFunction(settings.callback)) {


### PR DESCRIPTION
- it's possible to pass an object as settings.source. This object will be used as $.ajax() options. If you set settings.source.callback - the callback(text, ajaxOptions) will be called allowing to further modify the ajax options

``` js

  source:{
                callback : function(text, ajax) {
                    ajax.url = '/' + App.language + '/search.json';
                    if (App.map.getZoom() > 3) ajax.data.bounds = App.map.getBounds().toBBoxString();
                }
            }
  cache : true, // will set cache option to true
```
- don't query again if the text didn't change
- an option to query server not quicker, then specified interval (settings.interval)
- buildItems callback for building the result (settings.builder)

``` js

   builder : function(data, settings) {
     var s = [];
     // ...
     return s;
   }
```
- on desktop, it's possible to select results using up/down/enter keys
- configurable term parameter name (settings.termParam)
- configurable loading placeholder (settings.loadingHtml), which shows up despite the settings.cancelRequests option
