### PR TITLE
Integration with panrafal fork, addition of formatting callbacks

### DIFF
--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -86,7 +86,8 @@
                 $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').nextAll('li.ui-btn:eq(0)').addClass('ui-btn-active').length
                     || $('.ui-btn:first', $(settings.target)).addClass('ui-btn-active');
             } else if (e.keyCode == 13) {
-                $('.ui-btn-active a', $(settings.target)).click();
+                $('.ui-btn-active a', $(settings.target)).click().length
+                || $('.ui-btn:first a', $(settings.target)).click();
             }
         }
 		if (settings) {

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -80,10 +80,10 @@
 			re;
         if (e) {
             if (e.keyCode == 38) { // up
-                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prev('li.ui-btn').addClass('ui-btn-active').length
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prevAll('li.ui-btn:eq(0)').addClass('ui-btn-active').length
                     || $('.ui-btn:last', $(settings.target)).addClass('ui-btn-active');
             } else if (e.keyCode == 40) {
-                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').next('li.ui-btn').addClass('ui-btn-active').length
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').nextAll('li.ui-btn:eq(0)').addClass('ui-btn-active').length
                     || $('.ui-btn:first', $(settings.target)).addClass('ui-btn-active');
             } else if (e.keyCode == 13) {
                 $('.ui-btn-active a', $(settings.target)).click();

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -73,6 +73,9 @@
 		if (settings) {
 			// get the current text of the input field
 			text = $this.val();
+            // check if it's the same as the last one
+            if (settings._lastText === text) return;
+            settings._lastText = text;
 			// if we don't have enough text zero out the target
 			if (text.length < settings.minLength) {
 				clearTarget($this, $(settings.target));

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -78,6 +78,18 @@
 			settings = $this.jqmData("autocomplete"),
 			element_text,
 			re;
+        if (e) {
+            console.log(e.keyCode);
+            if (e.keyCode == 38) { // up
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prev('li.ui-btn').addClass('ui-btn-active').length
+                    || $('.ui-btn:last', $(settings.target)).addClass('ui-btn-active');
+            } else if (e.keyCode == 40) {
+                $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').next('li.ui-btn').addClass('ui-btn-active').length
+                    || $('.ui-btn:first', $(settings.target)).addClass('ui-btn-active');
+            } else if (e.keyCode == 13) {
+                $('.ui-btn-active a', $(settings.target)).click();
+            }
+        }
 		if (settings) {
 			// get the current text of the input field
 			text = $this.val();
@@ -87,6 +99,8 @@
             if (settings._retryTimeout) {
                 window.clearTimeout(settings._retryTimeout);
                 settings._retryTimeout = null;
+                // dont change the result the user is browsing...
+                if (e && (e.keyCode == 13 || e.keyCode == 38 || e.keyCode == 40)) return;
             }
 			// if we don't have enough text zero out the target
 			if (text.length < settings.minLength) {

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -79,7 +79,6 @@
 			element_text,
 			re;
         if (e) {
-            console.log(e.keyCode);
             if (e.keyCode == 38) { // up
                 $('.ui-btn-active', $(settings.target)).removeClass('ui-btn-active').prev('li.ui-btn').addClass('ui-btn-active').length
                     || $('.ui-btn:last', $(settings.target)).addClass('ui-btn-active');
@@ -99,9 +98,9 @@
             if (settings._retryTimeout) {
                 window.clearTimeout(settings._retryTimeout);
                 settings._retryTimeout = null;
-                // dont change the result the user is browsing...
-                if (e && (e.keyCode == 13 || e.keyCode == 38 || e.keyCode == 40)) return;
             }
+            // dont change the result the user is browsing...
+            if (e && (e.keyCode == 13 || e.keyCode == 38 || e.keyCode == 40)) return;
 			// if we don't have enough text zero out the target
 			if (text.length < settings.minLength) {
 				clearTarget($this, $(settings.target));

--- a/jqm.autoComplete-1.4.2.js
+++ b/jqm.autoComplete-1.4.2.js
@@ -24,22 +24,29 @@
 		matchFromStart: true,
         termParam : 'term',
         loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>',
-        interval : 0
+        interval : 0,
+        builder : null
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
-		var str = [];
-		if (data) {
-			$.each(data, function(index, value) {
-				// are we working with objects or strings?
-				if ($.isPlainObject(value)) {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
-				} else {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
-				}
-			});
-		}
-		$(settings.target).html(str.join('')).listview("refresh");
+		var str;
+        if (settings.builder) {
+            str = settings.builder.apply($this.eq(0), [data, settings]);
+        } else {
+            str = [];
+            if (data) {
+                $.each(data, function(index, value) {
+                    // are we working with objects or strings?
+                    if ($.isPlainObject(value)) {
+                        str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '">' + value.label + '</a></li>');
+                    } else {
+                        str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
+                    }
+                });
+            }
+        }
+        if ($.isArray(str)) str = str.join('');
+		$(settings.target).html(str).listview("refresh");
 
 		// is there a callback?
 		if (settings.callback !== null && $.isFunction(settings.callback)) {

--- a/jqm.autoComplete-1.4.3.js
+++ b/jqm.autoComplete-1.4.3.js
@@ -23,7 +23,8 @@
 		transition: 'fade',
 		matchFromStart: true,
         remoteDelay: 0,
-        labelHTML: function(value) { return value; }
+        labelHTML: function(value) { return value; },
+        onNoResults: function() { return; }
 	},
 	openXHR = {},
     state   = {
@@ -54,6 +55,10 @@
 			$this.trigger("targetUpdated.autocomplete");
 		} else {
 			$this.trigger("targetCleared.autocomplete");
+
+            if (settings.onNoResults) {
+                settings.onNoResults();
+            }
 		}
 	},
 	attachCallback = function(settings) {

--- a/jqm.autoComplete-1.4.3.js
+++ b/jqm.autoComplete-1.4.3.js
@@ -120,7 +120,6 @@
                     settings._retryTimeout = window.setTimeout($.proxy(handleInput, this), settings.interval - Date.now() + settings._lastRequest );
                     return;
                 }
-                console.log('search');
                 settings._lastRequest = Date.now();
                 // store last text
                 settings._lastText = text;

--- a/jqm.autoComplete-1.4.3.js
+++ b/jqm.autoComplete-1.4.3.js
@@ -22,7 +22,8 @@
 		minLength: 0,
 		transition: 'fade',
 		matchFromStart: true,
-        remoteDelay: 0
+        remoteDelay: 0,
+        html: function(value) { return value; }
 	},
 	openXHR = {},
     state   = {
@@ -36,9 +37,9 @@
 			$.each(data, function(index, value) {
 				// are we working with objects or strings?
 				if ($.isPlainObject(value)) {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value) + '\'>' + value.label + '</a></li>');
+					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value) + '\'>' + settings.html(value.label) + '</a></li>');
 				} else {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + value + '</a></li>');
+					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + settings.html(value) + '</a></li>');
 				}
 			});
 		}

--- a/jqm.autoComplete-1.4.3.js
+++ b/jqm.autoComplete-1.4.3.js
@@ -23,7 +23,7 @@
 		transition: 'fade',
 		matchFromStart: true,
         remoteDelay: 0,
-        html: function(value) { return value; }
+        labelHTML: function(value) { return value; }
 	},
 	openXHR = {},
     state   = {
@@ -37,9 +37,9 @@
 			$.each(data, function(index, value) {
 				// are we working with objects or strings?
 				if ($.isPlainObject(value)) {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value) + '\'>' + settings.html(value.label) + '</a></li>');
+					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value) + '\'>' + settings.labelHTML(value.label) + '</a></li>');
 				} else {
-					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + settings.html(value) + '</a></li>');
+					str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + settings.labelHTML(value) + '</a></li>');
 				}
 			});
 		}

--- a/jqm.autoComplete-1.4.3.js
+++ b/jqm.autoComplete-1.4.3.js
@@ -25,7 +25,7 @@
         labelHTML: function(value) { return value; },
         onNoResults: function() { return; },
         onLoading: function() { return; },
-        onLoadingFinished: function() { return; }
+        onLoadingFinished: function() { return; },
         termParam : 'term',
         loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>',
         interval : 0,
@@ -120,6 +120,7 @@
                     settings._retryTimeout = window.setTimeout($.proxy(handleInput, this), settings.interval - Date.now() + settings._lastRequest );
                     return;
                 }
+                console.log('search');
                 settings._lastRequest = Date.now();
                 // store last text
                 settings._lastText = text;
@@ -190,7 +191,6 @@
                                 settings.onLoadingFinished();
                             }
 						},
-						dataType: 'json'
 					};
 
                     if ($.isPlainObject(settings.source)) {

--- a/jqm.autoComplete-1.4.3.js
+++ b/jqm.autoComplete-1.4.3.js
@@ -24,7 +24,9 @@
 		matchFromStart: true,
         remoteDelay: 0,
         labelHTML: function(value) { return value; },
-        onNoResults: function() { return; }
+        onNoResults: function() { return; },
+        onRemote: function() { return; },
+        onRemoteFinished: function() { return; }
 	},
 	openXHR = {},
     state   = {
@@ -161,6 +163,10 @@
 								// Set this request to the open XML HTTP Request list for this ID
 								openXHR[id] = jqXHR;
 							}
+
+                            if (settings.onRemote && settings.onRemoteFinished) {
+                                settings.onRemote();
+                            }
 						},
 						success: function(data) {
 							buildItems($this, data, settings);
@@ -170,6 +176,10 @@
 							if (settings.cancelRequests) {
 								openXHR[id] = null;
 							}
+
+                            if (settings.onRemoteFinished) {
+                                settings.onRemoteFinished();
+                            }
 						},
 						dataType: 'json'
 					});

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,8 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
 		link: 'target.html?term=', // link to be attached to each result
 		minLength: 0 // minimum length of search string
 		transition: 'fade',// page transition, default is fade
-		matchFromStart: true // search from start, or anywhere in the string
+		matchFromStart: true, // search from start, or anywhere in the string
+        remoteDelay: 0 // The minimum delay between server calls when using a remote "source"
 	});
 
 AutoComplete can access local arrays or remote data sources.

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
         remoteDelay: 0, // The minimum delay between server calls when using a remote "source"
         labelHTML: fn(){}, // optioanl callback function when formatting the display value of list items
         onNoResults: fn(), // optional callback function when no results were matched
+        onRemote: fn(), // optional callback function called just prior to ajax call
+        onRemoteFinished: fn(), // optioanl callback function called just after ajax call has completed
 	});
 
 AutoComplete can access local arrays or remote data sources.

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
 		matchFromStart: true, // search from start, or anywhere in the string
         remoteDelay: 0, // The minimum delay between server calls when using a remote "source"
         labelHTML: fn(){}, // optioanl callback function when formatting the display value of list items
+        onNoResults: fn(), // optional callback function when no results were matched
 	});
 
 AutoComplete can access local arrays or remote data sources.

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,8 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
 		minLength: 0 // minimum length of search string
 		transition: 'fade',// page transition, default is fade
 		matchFromStart: true, // search from start, or anywhere in the string
-        remoteDelay: 0 // The minimum delay between server calls when using a remote "source"
+        remoteDelay: 0, // The minimum delay between server calls when using a remote "source"
+        labelHTML: fn(){}, // optioanl callback function when formatting the display value of list items
 	});
 
 AutoComplete can access local arrays or remote data sources.

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,13 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
 		minLength: 0 // minimum length of search string
 		transition: 'fade',// page transition, default is fade
 		matchFromStart: true, // search from start, or anywhere in the string
-        remoteDelay: 0, // The minimum delay between server calls when using a remote "source"
+        loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>', // HTML to display when searching remotely
+        interval: 0, // The minimum delay between server calls when using a remote "source"
+        builder : null, // optional callback to build HTML for autocomplete
         labelHTML: fn(){}, // optioanl callback function when formatting the display value of list items
         onNoResults: fn(), // optional callback function when no results were matched
-        onRemote: fn(), // optional callback function called just prior to ajax call
-        onRemoteFinished: fn(), // optioanl callback function called just after ajax call has completed
+        onLoading: fn(), // optional callback function called just prior to ajax call
+        onLoadingFinished: fn(), // optioanl callback function called just after ajax call has completed
 	});
 
 AutoComplete can access local arrays or remote data sources.


### PR DESCRIPTION
I've added a few callback hooks, a merge of panrafal's fork (in a pending pull request) and corresponding documentation. This pull has been well tested and the fork is currently being used in a Production environment with no issues. Changes include:
- Format callbacks, called when clicking links
- Callback to adjust label text
- Callback called when no results are returned
- Addition of wrapper callbacks, called around the .ajax call; before and after.
