### PR TITLE
IE8 bug

### DIFF
--- a/jqm.autoComplete-1.5.0.js
+++ b/jqm.autoComplete-1.5.0.js
@@ -92,6 +92,13 @@
 			element_text,
 			re;
 
+		// Fix For IE8 and earlier versions.
+		if (!Date.now) {
+			Date.now = function() {
+				return new Date().valueOf();
+			}
+		}
+
 		if (e) {
 			if (e.keyCode === 38) { // up
 				$('.ui-btn-active', $(settings.target))


### PR DESCRIPTION
Fixed problem in IE8, which doesn't have Date.now().

See https://github.com/commadelimited/autoComplete.js/issues/42
