### PR TITLE
Update jqm.autoComplete-1.5.0.js

### DIFF
--- a/jqm.autoComplete-1.5.0.js
+++ b/jqm.autoComplete-1.5.0.js
@@ -192,8 +192,8 @@
 
 							if (settings.loadingHtml) {
 								// Set a loading indicator as a temporary stop-gap to the response time issue
-								settings.target.html(settings.loadingHtml).listview('refresh');
-								settings.target.closest("fieldset").addClass("ui-search-active");
+								$(settings.target).html(settings.loadingHtml).listview('refresh');
+								$(settings.target).closest("fieldset").addClass("ui-search-active");
 							}
 						},
 						success: function(data) {


### PR DESCRIPTION
ln 195/196 were breaking in chrome's console - no method error html() on the settings.target string
