### PR TITLE
Encode ' in json output

### DIFF
--- a/jqm.autoComplete-1.5.1.js
+++ b/jqm.autoComplete-1.5.1.js
@@ -42,7 +42,7 @@
 				$.each(data, function(index, value) {
 					// are we working with objects or strings?
 					if ($.isPlainObject(value)) {
-						str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value) + '\'>' + settings.labelHTML(value.label) + '</a></li>');
+						str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value).replace(/'/g, "&#39;") + '\'>' + settings.labelHTML(value.label) + '</a></li>');
 					} else {
 						str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + settings.labelHTML(value) + '</a></li>');
 					}


### PR DESCRIPTION
When an option was for an object, and that object had a property with a ' in it, the html that is written out is invalid. In the callback function when $(e.currentTarget).data("autocomplete") is used, some of the properties would end up undefined. Encode ' as &#39; when writing out the json value of an object.
