### PR TITLE
Add an optional function to convert the received JSON data

### DIFF
--- a/jqm.autoComplete-1.5.1.js
+++ b/jqm.autoComplete-1.5.1.js
@@ -29,7 +29,8 @@
 		termParam : 'term',
 		loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>',
 		interval : 0,
-		builder : null
+		builder : null,
+                dataHandler : null
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
@@ -39,6 +40,9 @@
 		} else {
 			str = [];
 			if (data) {
+                                if (settings.dataHandler) {
+                                        data = settings.dataHandler(data);
+                                }
 				$.each(data, function(index, value) {
 					// are we working with objects or strings?
 					if ($.isPlainObject(value)) {

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
         onNoResults: fn(), // optional callback function when no results were matched
         onLoading: fn(), // optional callback function called just prior to ajax call
         onLoadingFinished: fn(), // optioanl callback function called just after ajax call has completed
+        datahandler : fn(), // optional function to convert the received JSON data to the format described below
 	});
 
 AutoComplete can access local arrays or remote data sources.


### PR DESCRIPTION
My autosuggestion data comes back from a Solr server, which has its own, very particular format.  I would like to add a function to convert it into the simplified format.  This patch should do the trick.

Thanks for the great plugin!  :)
