### PR TITLE
Store last text before early return

### DIFF
--- a/jqm.autoComplete-1.5.1.js
+++ b/jqm.autoComplete-1.5.1.js
@@ -123,6 +123,8 @@
 			if (settings._lastText === text) {
 				return;
 			}
+			// store last text
+			settings._lastText = text;
 			// reset the timeout...
 			if (settings._retryTimeout) {
 				window.clearTimeout(settings._retryTimeout);
@@ -141,8 +143,6 @@
 					return;
 				}
 				settings._lastRequest = Date.now();
-				// store last text
-				settings._lastText = text;
 
 				// are we looking at a source array or remote data?
 				if ($.isArray(settings.source)) {


### PR DESCRIPTION
Last text value should be stored always, not just when the input is of sufficient length.

Currently if you have an input string with length equal to the minimum length, then delete a character and retype the same character the autocomplete will not fire (since text === settings._lastText, erroneously). This commit fixes that.
