### PR TITLE
Enable class of li element for results to be set. (repeat pull request of #55)

### DIFF
--- a/jqm.autoComplete-1.5.1.js
+++ b/jqm.autoComplete-1.5.1.js
@@ -29,26 +29,31 @@
 		termParam : 'term',
 		loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>',
 		interval : 0,
-		builder : null,
-                dataHandler : null
+		builder: null,
+		dataHandler : null
+		class: null
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
 		var str;
+		var vclass = '';
+		if (settings.class) {
+			vclass = 'class="' + settings.class + '"';
+		}
 		if (settings.builder) {
 			str = settings.builder.apply($this.eq(0), [data, settings]);
 		} else {
 			str = [];
 			if (data) {
-                                if (settings.dataHandler) {
-                                        data = settings.dataHandler(data);
-                                }
+				if (settings.dataHandler) {
+				    data = settings.dataHandler(data);
+				}
 				$.each(data, function(index, value) {
 					// are we working with objects or strings?
 					if ($.isPlainObject(value)) {
-						str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value).replace(/'/g, "&#39;") + '\'>' + settings.labelHTML(value.label) + '</a></li>');
+						str.push('<li ' + vclass + ' data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value.value) + '" data-transition="' + settings.transition + '" data-autocomplete=\'' + JSON.stringify(value).replace(/'/g, "&#39;") + '\'>' + settings.labelHTML(value.label) + '</a></li>');
 					} else {
-						str.push('<li data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + settings.labelHTML(value) + '</a></li>');
+						str.push('<li ' + vclass + ' data-icon=' + settings.icon + '><a href="' + settings.link + encodeURIComponent(value) + '" data-transition="' + settings.transition + '">' + settings.labelHTML(value) + '</a></li>');
 					}
 				});
 			}

--- a/readme.md
+++ b/readme.md
@@ -23,14 +23,15 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
 		minLength: 0 // minimum length of search string
 		transition: 'fade',// page transition, default is fade
 		matchFromStart: true, // search from start, or anywhere in the string
-        loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>', // HTML to display when searching remotely
-        interval: 0, // The minimum delay between server calls when using a remote "source"
-        builder : null, // optional callback to build HTML for autocomplete
-        labelHTML: fn(){}, // optioanl callback function when formatting the display value of list items
-        onNoResults: fn(), // optional callback function when no results were matched
-        onLoading: fn(), // optional callback function called just prior to ajax call
-        onLoadingFinished: fn(), // optioanl callback function called just after ajax call has completed
-        datahandler : fn(), // optional function to convert the received JSON data to the format described below
+		loadingHtml : '<li data-icon="none"><a href="#">Searching...</a></li>', // HTML to display when searching remotely
+		interval: 0, // The minimum delay between server calls when using a remote "source"
+		builder : null, // optional callback to build HTML for autocomplete
+		labelHTML: fn(){}, // optional callback function when formatting the display value of list items
+		onNoResults: fn(), // optional callback function when no results were matched
+		onLoading: fn(), // optional callback function called just prior to ajax call
+		onLoadingFinished: fn(), // optional callback function called just after ajax call has completed
+		datahandler : fn(), // optional function to convert the received JSON data to the format described below
+		class: 'tinted' // optional class name for listview's <li> tag
 	});
 
 AutoComplete can access local arrays or remote data sources.


### PR DESCRIPTION
E.g:

```
$("#search").autocomplete({
    minLength: 2,
    class: 'dashed',
    target: $('#results')
});
```
