### PR TITLE
Optionally, do not force the first choice when the enter key is hit

### DIFF
--- a/jqm.autoComplete-1.5.1.js
+++ b/jqm.autoComplete-1.5.1.js
@@ -31,7 +31,8 @@
 		interval : 0,
 		builder: null,
 		dataHandler : null,
-		class: null
+		class: null,
+		forceFirstChoiceOnEnterKey : true
 	},
 	openXHR = {},
 	buildItems = function($this, data, settings) {
@@ -116,7 +117,7 @@
 					.removeClass('ui-btn-active').nextAll('li.ui-btn:eq(0)')
 					.addClass('ui-btn-active').length ||
 						$('.ui-btn:first', $(settings.target)).addClass('ui-btn-active');
-			} else if (e.keyCode === 13) {
+			} else if (e.keyCode === 13 && settings.forceFirstChoiceOnEnterKey) {
 				$('.ui-btn-active a', $(settings.target)).click().length  || $('.ui-btn:first a', $(settings.target)).click();
 			}
 		}

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ Clone the git repo - `git clone https://github.com/commadelimited/autoComplete.j
 		onLoading: fn(), // optional callback function called just prior to ajax call
 		onLoadingFinished: fn(), // optional callback function called just after ajax call has completed
 		datahandler : fn(), // optional function to convert the received JSON data to the format described below
-		class: 'tinted' // optional class name for listview's <li> tag
+		class: 'tinted', // optional class name for listview's <li> tag
+		forceFirstChoiceOnEnterKey : true // force the first choice in the list when Enter key is hit
 	});
 
 AutoComplete can access local arrays or remote data sources.


### PR DESCRIPTION
This is something that came in handy for me.

**Steps to reproduce:**
1. Go to the [example site](http://andymatthews.net/code/autocomplete/)
2. Type "m"
3. Hit the enter key

**Result:** "Maine" is forcefully chosen as the search term.

Now, I can imagine cases where this would be desired (e.g. a list of the 50 states) and cases where this would not be desired (e.g. a general-purpose search engine where the user types in `basket` and the first suggestion is `basketball`).

So I'm suggesting adding an option to disable it.
